### PR TITLE
Fix encoding error for export feature

### DIFF
--- a/js/plugin-report.js
+++ b/js/plugin-report.js
@@ -85,7 +85,7 @@ jQuery(document).ready( function( $ ){
 		var link = document.createElement( 'a' );
 		var now = new Date();
 		link.download = 'plugin-report-' + now.getFullYear() + '-' + String( '0' + now.getMonth() ).slice(-2) + '-' + String( '0' + now.getDate() ).slice(-2) + '.xls';
-		link.href = uri + btoa( format( template, ctx ) );
+		link.href = uri + btoa( unescape( encodeURIComponent( format( template, ctx ) ) ) );
 		link.click();
 		link.remove();
 	}

--- a/js/plugin-report.js
+++ b/js/plugin-report.js
@@ -72,7 +72,7 @@ jQuery(document).ready( function( $ ){
 	function rtpr_export_table(){
 		var table_html = $('#plugin-report-table').html();
 		var uri = 'data:application/vnd.ms-excel;charset=UTF-8;base64,';
-		var template = '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40"><head><!--[if gte mso 9]><xml><x:ExcelWorkbook><x:ExcelWorksheets><x:ExcelWorksheet><x:Name>{worksheet}</x:Name><x:WorksheetOptions><x:DisplayGridlines/></x:WorksheetOptions></x:ExcelWorksheet></x:ExcelWorksheets></x:ExcelWorkbook></xml><![endif]--></head><body><table>{table}</table></body></html>';
+		var template = '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40"><head><!--[if gte mso 9]><xml><x:ExcelWorkbook><x:ExcelWorksheets><x:ExcelWorksheet><x:Name>{worksheet}</x:Name><x:WorksheetOptions><x:DisplayGridlines/></x:WorksheetOptions></x:ExcelWorksheet></x:ExcelWorksheets></x:ExcelWorkbook></xml><![endif]--><meta http-equiv="content-type" content="text/plain; charset=UTF-8"/></head><body><table>{table}</table></body></html>';
 		var format = function(s, c) {
 			return s.replace(/{(\w+)}/g, function(m, p) {
 				return c[p];


### PR DESCRIPTION
This fixes the "The string to be encoded contains characters outside of the Latin1 range." error in Safari/Chrome.
Based on the fix by Johan Sundström from https://developer.mozilla.org/de/docs/Web/API/WindowBase64/btoa

Fixes #15 