### PR TITLE
Enable default sorting on name column

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -131,7 +131,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			echo '<table id="plugin-report-table" class="wp-list-table widefat fixed striped">';
 			echo '<thead>';
 			echo '<tr>';
-			echo '<th>' . esc_html__( 'Name', 'plugin-report' ) . '</th>';
+			echo '<th data-sort-default>' . esc_html__( 'Name', 'plugin-report' ) . '</th>';
 			echo '<th>' . esc_html__( 'Author', 'plugin-report' ) . '</th>';
 			echo '<th>' . esc_html__( 'Activated', 'plugin-report' ) . '</th>';
 			echo '<th data-sort-method="none" class="no-sort">' . esc_html__( 'Installed version', 'plugin-report' ) . '</th>';


### PR DESCRIPTION
Fixes partially #38

The table was using the order coming from the plugin directory and on init wasn't sorted at all. Specifying a default sorting column fixes this. (See: http://tristen.ca/tablesort/demo/)

Translated plugin names still not fixed.