### PR TITLE
Check wordpress.org only if "Update URI" plugin header is not set

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -339,7 +339,10 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 						),
 					);
 
-					$returned_object = plugins_api( 'plugin_information', $args );
+					// Check wordpress.org only if "Update URI" plugin header is not set.
+					if ( ! $report['local_info']['UpdateURI'] ) {
+						$returned_object = plugins_api( 'plugin_information', $args );
+					}
 
 					// Add the repo info to the report.
 					if ( ! is_wp_error( $returned_object ) ) {


### PR DESCRIPTION
WordPress 5.8 has introduced a new plugin header called "Update URI" which can be used to stop the update check for a plugin (for example if you have used a slug for a custom plugin that is already used on wordpress.org).

Details can be found here: 
https://make.wordpress.org/core/2021/06/29/introducing-update-uri-plugin-header-in-wordpress-5-8/

This PR adds a check if the header is set and then does not use the `plugins_api` call.

Fixes #43 