### PR TITLE
Show better info for repository column on WP <5.8

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -464,6 +464,8 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 							$html .= '<td class="' . self::CSS_CLASS_MED . '">' . __( 'Updates disabled', 'plugin-report' ) . '</td>';
 						}
 					}
+				} else if ( version_compare( $wp_version, '5.8', '<' ) ) {
+					$html .= $this->render_error_cell( esc_html__( 'Only available in WP 5.8+', 'plugin-report' ) );
 				} else {
 					$html .= $this->render_error_cell();
 				}


### PR DESCRIPTION
Adding the required WP version to the repository column info to better inform the user about why the data is missing.

Fixes #53 