### PR TITLE
Fix sorting

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -581,7 +581,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			if ( ! $message ) {
 				$message = esc_html__( 'No data available', 'plugin-report' );
 			}
-			return '<td class="pluginreport-cell-error">' . $message . '</td>';
+			return '<td class="pluginreport-cell-error" data-sort="0">' . $message . '</td>';
 		}
 
 


### PR DESCRIPTION
Add data-sort attribute with custom value of 0 to fix broken sorting if there are rows with no data available for the "Tested up to" version.

Fixes #59