### PR TITLE
Add local readme.txt fallback for Tested up to

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -322,6 +322,9 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 							// Change any whitespace to default space.
 							$report['local_info']['Name'] = preg_replace( '/\s+/u', ' ', $report['local_info']['Name'] );
 
+							// Parse the local readme.txt for the "Tested up to" value.
+							$report['local_tested'] = $this->get_local_tested_up_to( $key );
+
 							break;
 						}
 					}
@@ -403,6 +406,45 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			}
 			// In all other cases, assume the plugin was not found.
 			return false;
+		}
+
+
+		/**
+		 * Parse the "Tested up to" value from a plugin's local readme.txt file.
+		 *
+		 * @param string $plugin_file Relative plugin file path (e.g. "plugin-name/plugin-name.php").
+		 *
+		 * @return string|null The "Tested up to" version string, or null if not found.
+		 */
+		private function get_local_tested_up_to( $plugin_file ) {
+			$plugin_dir = WP_PLUGIN_DIR . '/' . dirname( $plugin_file );
+
+			// Try readme.txt first, then readme.md.
+			$readme_path = null;
+			foreach ( array( 'readme.txt', 'README.txt', 'readme.md', 'README.md' ) as $filename ) {
+				if ( file_exists( $plugin_dir . '/' . $filename ) ) {
+					$readme_path = $plugin_dir . '/' . $filename;
+					break;
+				}
+			}
+
+			if ( ! $readme_path ) {
+				return null;
+			}
+
+			// Read only the first 8 KB — headers are always at the top.
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$content = file_get_contents( $readme_path, false, null, 0, 8192 );
+			if ( false === $content ) {
+				return null;
+			}
+
+			// Match "Tested up to: <version>" (case-insensitive).
+			if ( preg_match( '/^[ \t]*tested up to[ \t]*:[ \t]*(\d[^\r\n]*)/mi', $content, $matches ) ) {
+				return trim( $matches[1] );
+			}
+
+			return null;
 		}
 
 
@@ -546,6 +588,9 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 				if ( isset( $report['repo_info'] ) && isset( $report['repo_info']->tested ) && ! empty( $report['repo_info']->tested ) ) {
 					$css_class = $this->get_version_risk_classname( $report['repo_info']->tested, $wp_latest, true );
 					$html     .= '<td class="' . $css_class . '">' . esc_html( $report['repo_info']->tested ) . '</td>';
+				} elseif ( isset( $report['local_tested'] ) && ! empty( $report['local_tested'] ) ) {
+					$css_class = $this->get_version_risk_classname( $report['local_tested'], $wp_latest, true );
+					$html     .= '<td class="' . $css_class . '">' . esc_html( $report['local_tested'] ) . '</td>';
 				} else {
 					$html .= $this->render_error_cell();
 				}


### PR DESCRIPTION
## Summary

- Adds `get_local_tested_up_to()` method that parses the `Tested up to` header from a plugin's local `readme.txt` (or `readme.md`)
- Uses this local value as fallback when the wordpress.org API does not provide a `tested` value (e.g. non-wordpress.org plugins with custom `Update URI`)
- Escapes the displayed value with `esc_html()` (minor hardening)

Fixes #64

## Context

The `Tested up to` column currently relies exclusively on `plugins_api()`. This fails for:
1. **Non-wordpress.org plugins** (custom `Update URI`) — no API call is made, column shows "No data available"
2. **Third-party updaters** (e.g. Git Updater) — may inject incorrect values via `plugins_api` filters

The local readme.txt is the authoritative source for the installed version's compatibility declaration and serves as a reliable fallback.

## Test in WordPress Playground

**Before (develop — no fallback):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL1pvZGlhYzE5NzgvcGx1Z2luLXJlcG9ydC9hcmNoaXZlL3JlZnMvaGVhZHMvZGV2ZWxvcC56aXAifX0seyJzdGVwIjoiYWN0aXZhdGVQbHVnaW4iLCJwbHVnaW5QYXRoIjoicGx1Z2luLXJlcG9ydC1kZXZlbG9wL3J0LXBsdWdpbi1yZXBvcnQucGhwIn0seyJzdGVwIjoiaW5zdGFsbFBsdWdpbiIsInBsdWdpblppcEZpbGUiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL2Rvd25sb2Fkcy53b3JkcHJlc3Mub3JnL3BsdWdpbi9hcGVybW8tYWRtaW5iYXIuemlwIn19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vZ2l3ZWF0aGVyLnppcCJ9fV0sImZlYXR1cmVzIjp7Im5ldHdvcmtpbmciOnRydWV9fQ==)

**After (this branch — readme.txt fallback):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FwZXJtby9wbHVnaW4tcmVwb3J0L2FyY2hpdmUvcmVmcy9oZWFkcy9maXgvdGVzdGVkLXVwLXRvLWZyb20tcmVhZG1lLnppcCJ9fSx7InN0ZXAiOiJhY3RpdmF0ZVBsdWdpbiIsInBsdWdpblBhdGgiOiJwbHVnaW4tcmVwb3J0LWZpeC10ZXN0ZWQtdXAtdG8tZnJvbS1yZWFkbWUvcnQtcGx1Z2luLXJlcG9ydC5waHAifSx7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luWmlwRmlsZSI6eyJyZXNvdXJjZSI6InVybCIsInVybCI6Imh0dHBzOi8vZG93bmxvYWRzLndvcmRwcmVzcy5vcmcvcGx1Z2luL2FwZXJtby1hZG1pbmJhci56aXAifX0seyJzdGVwIjoiaW5zdGFsbFBsdWdpbiIsInBsdWdpblppcEZpbGUiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL2Rvd25sb2Fkcy53b3JkcHJlc3Mub3JnL3BsdWdpbi9naXdlYXRoZXIuemlwIn19XX0=)

Pre-installed test plugins: [Apermo Admin Bar](https://wordpress.org/plugins/apermo-adminbar/) (outdated), [giWeather](https://wordpress.org/plugins/giweather/) (closed/removed)

## Test plan

- [ ] Open the **Before** link — non-wordpress.org plugins show "No data available" in the Tested up to column
- [ ] Open the **After** link — those same plugins show the value parsed from their local readme.txt
- [ ] Verify wordpress.org plugins still show the API value (primary source unchanged)
- [ ] Clear cache and reload to confirm the fallback works on fresh data