### PR TITLE
Add public plugin_report_get_data() API

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -835,5 +835,4 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 	function plugin_report_get_data( $slug ) {
 		return RT_Plugin_Report::get_report( $slug );
 	}
-
 }

--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -145,7 +145,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 
 			foreach ( $plugins as $key => $plugin ) {
 				$slug  = $this->get_plugin_slug( $key );
-				$cache = self::get_report( $slug );
+				$cache = $this->get_report( $slug );
 				if ( $cache ) {
 					// Use the cached report to create a table row.
 					echo $this->render_table_row( $cache );
@@ -783,7 +783,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 		 *
 		 * @return array|null Report data array, or null if the slug is empty or not found.
 		 */
-		public static function get_report( $slug ) {
+		public function get_report( $slug ) {
 			if ( empty( $slug ) ) {
 				return null;
 			}
@@ -793,15 +793,14 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 			}
 
-			$instance = new self();
-			$cache_key = $instance->create_cache_key( $slug );
+			$cache_key = $this->create_cache_key( $slug );
 			$cache     = get_site_transient( $cache_key );
 
 			if ( ! empty( $cache ) ) {
 				return $cache;
 			}
 
-			return $instance->assemble_plugin_report( $slug );
+			return $this->assemble_plugin_report( $slug );
 		}
 
 	}
@@ -814,9 +813,10 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 	/**
 	 * Public API: get Plugin Report data for a plugin.
 	 *
-	 * Convenience wrapper around RT_Plugin_Report::get_report(). Returns cached
-	 * data when available, otherwise fetches fresh data from the wordpress.org API
-	 * and caches it. Safe to call from any plugin — if Plugin Report is not active
+	 * Convenience wrapper around RT_Plugin_Report::get_report(). Uses a static
+	 * instance to avoid repeated object creation. Returns cached data when
+	 * available, otherwise fetches fresh data from the wordpress.org API and
+	 * caches it. Safe to call from any plugin — if Plugin Report is not active
 	 * or the slug is invalid, returns null.
 	 *
 	 * Example usage:
@@ -833,6 +833,10 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 	 * @return array|null Report data array, or null if not available.
 	 */
 	function plugin_report_get_data( $slug ) {
-		return RT_Plugin_Report::get_report( $slug );
+		static $plugin_report = null;
+		if ( null === $plugin_report ) {
+			$plugin_report = new RT_Plugin_Report();
+		}
+		return $plugin_report->get_report( $slug );
 	}
 }

--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -823,7 +823,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 	 *
 	 *     if ( function_exists( 'plugin_report_get_data' ) ) {
 	 *         $report = plugin_report_get_data( 'akismet' );
-	 *         if ( $report && isset( $report['repo_info'] ) ) {
+	 *         if ( isset( $report['repo_info'] ) ) {
 	 *             echo $report['repo_info']->tested;
 	 *         }
 	 *     }

--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -144,9 +144,8 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			echo '<tbody>';
 
 			foreach ( $plugins as $key => $plugin ) {
-				$slug      = $this->get_plugin_slug( $key );
-				$cache_key = $this->create_cache_key( $slug );
-				$cache     = get_site_transient( $cache_key );
+				$slug  = $this->get_plugin_slug( $key );
+				$cache = self::get_report( $slug );
 				if ( $cache ) {
 					// Use the cached report to create a table row.
 					echo $this->render_table_row( $cache );
@@ -773,10 +772,68 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			}
 		}
 
+		/**
+		 * Public API: get the report data for a plugin.
+		 *
+		 * Returns cached data when available, otherwise assembles a fresh report
+		 * (which also populates the cache). This is the recommended way for other
+		 * plugins to read Plugin Report data without accessing transients directly.
+		 *
+		 * @param string $slug Plugin slug (e.g. "akismet").
+		 *
+		 * @return array|null Report data array, or null if the slug is empty or not found.
+		 */
+		public static function get_report( $slug ) {
+			if ( empty( $slug ) ) {
+				return null;
+			}
+
+			// Check if get_plugins() function exists.
+			if ( ! function_exists( 'plugins_api' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			}
+
+			$instance = new self();
+			$cache_key = $instance->create_cache_key( $slug );
+			$cache     = get_site_transient( $cache_key );
+
+			if ( ! empty( $cache ) ) {
+				return $cache;
+			}
+
+			return $instance->assemble_plugin_report( $slug );
+		}
+
 	}
 
 	// Instantiate the class.
 	$plugin_report_instance = new RT_Plugin_Report();
 	$plugin_report_instance->init();
+
+
+	/**
+	 * Public API: get Plugin Report data for a plugin.
+	 *
+	 * Convenience wrapper around RT_Plugin_Report::get_report(). Returns cached
+	 * data when available, otherwise fetches fresh data from the wordpress.org API
+	 * and caches it. Safe to call from any plugin — if Plugin Report is not active
+	 * or the slug is invalid, returns null.
+	 *
+	 * Example usage:
+	 *
+	 *     if ( function_exists( 'plugin_report_get_data' ) ) {
+	 *         $report = plugin_report_get_data( 'akismet' );
+	 *         if ( $report && isset( $report['repo_info'] ) ) {
+	 *             echo $report['repo_info']->tested;
+	 *         }
+	 *     }
+	 *
+	 * @param string $slug Plugin slug (e.g. "akismet").
+	 *
+	 * @return array|null Report data array, or null if not available.
+	 */
+	function plugin_report_get_data( $slug ) {
+		return RT_Plugin_Report::get_report( $slug );
+	}
 
 }


### PR DESCRIPTION
## Summary

- Adds `RT_Plugin_Report::get_report( $slug )` static method as the canonical way to read report data
- Adds global `plugin_report_get_data( $slug )` convenience wrapper for use by other plugins
- Both return cached data or assemble a fresh report on demand
- Report page rendering updated to use `self::get_report()` internally

Fixes #87

## Test in WordPress Playground

**Before (develop — baseline):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luWmlwRmlsZSI6eyJyZXNvdXJjZSI6InVybCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ab2RpYWMxOTc4L3BsdWdpbi1yZXBvcnQvYXJjaGl2ZS9yZWZzL2hlYWRzL2RldmVsb3AuemlwIn19LHsic3RlcCI6ImFjdGl2YXRlUGx1Z2luIiwicGx1Z2luUGF0aCI6InBsdWdpbi1yZXBvcnQtZGV2ZWxvcC9ydC1wbHVnaW4tcmVwb3J0LnBocCJ9LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vYXBlcm1vLWFkbWluYmFyLnppcCJ9fSx7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luWmlwRmlsZSI6eyJyZXNvdXJjZSI6InVybCIsInVybCI6Imh0dHBzOi8vZG93bmxvYWRzLndvcmRwcmVzcy5vcmcvcGx1Z2luL2dpd2VhdGhlci56aXAifX1dfQ==)

**After (this branch — public API added):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FwZXJtby9wbHVnaW4tcmVwb3J0L2FyY2hpdmUvcmVmcy9oZWFkcy9mZWF0dXJlL3B1YmxpYy1hcGkuemlwIn19LHsic3RlcCI6ImFjdGl2YXRlUGx1Z2luIiwicGx1Z2luUGF0aCI6InBsdWdpbi1yZXBvcnQtZmVhdHVyZS1wdWJsaWMtYXBpL3J0LXBsdWdpbi1yZXBvcnQucGhwIn0seyJzdGVwIjoiaW5zdGFsbFBsdWdpbiIsInBsdWdpblppcEZpbGUiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL2Rvd25sb2Fkcy53b3JkcHJlc3Mub3JnL3BsdWdpbi9hcGVybW8tYWRtaW5iYXIuemlwIn19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vZ2l3ZWF0aGVyLnppcCJ9fV19)

Pre-installed test plugins: [Apermo Admin Bar](https://wordpress.org/plugins/apermo-adminbar/) (outdated), [giWeather](https://wordpress.org/plugins/giweather/) (closed/removed)

## Test plan

- [ ] Open both links — verify identical report page behavior (no regression)
- [ ] In the **After** link, verify `function_exists( 'plugin_report_get_data' )` returns true when plugin is active
- [ ] Verify `plugin_report_get_data('akismet')` returns report data