### PR TITLE
Add PLUGIN_REPORT_IGNORE constant for internal/paid plugins

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -273,6 +273,30 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 
 
 		/**
+		 * Check if a plugin slug is on the ignore list.
+		 *
+		 * The ignore list is read from the PLUGIN_REPORT_IGNORE constant, which
+		 * can be defined in wp-config.php as a comma-separated string or an array.
+		 *
+		 * @param string $slug Plugin slug.
+		 *
+		 * @return bool True if the plugin should be ignored.
+		 */
+		private function is_ignored( $slug ) {
+			if ( ! defined( 'PLUGIN_REPORT_IGNORE' ) ) {
+				return false;
+			}
+
+			$ignore_list = PLUGIN_REPORT_IGNORE;
+			if ( is_string( $ignore_list ) ) {
+				$ignore_list = array_map( 'trim', explode( ',', $ignore_list ) );
+			}
+
+			return is_array( $ignore_list ) && in_array( $slug, $ignore_list, true );
+		}
+
+
+		/**
 		 * Gather all the info we can get about a plugin.
 		 * Uses transient caching to avoid doing repo API calls on every page visit.
 		 *
@@ -326,27 +350,33 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 						}
 					}
 
-					// Use the wordpress.org repository API to get detailed information.
-					$args = array(
-						'slug'   => $slug,
-						'fields' => array(
-							'description'   => false,
-							'sections'      => false,
-							'tags'          => false,
-							'version'       => true,
-							'tested'        => true,
-							'requires'      => true,
-							'requires_php'  => true,
-							'compatibility' => true,
-							'author'        => true,
-						),
-					);
+					// Skip API lookups for ignored plugins.
+					if ( $this->is_ignored( $slug ) ) {
+						$report['ignored'] = true;
+						set_site_transient( $cache_key, $report, self::CACHE_LIFETIME_NOREPO );
+					} else {
+						// Use the wordpress.org repository API to get detailed information.
+						$args = array(
+							'slug'   => $slug,
+							'fields' => array(
+								'description'   => false,
+								'sections'      => false,
+								'tags'          => false,
+								'version'       => true,
+								'tested'        => true,
+								'requires'      => true,
+								'requires_php'  => true,
+								'compatibility' => true,
+								'author'        => true,
+							),
+						);
 
-					// Check wordpress.org only if "Update URI" plugin header is not set or set to wordpress.org.
-					$parsed_repo_url = wp_parse_url( $report['local_info']['UpdateURI'] );
-					$repo_host       = isset( $parsed_repo_url['host'] ) ? $parsed_repo_url['host'] : null;
-					if ( empty( $repo_host ) || strtolower( $repo_host ) === 'w.org' || strtolower( $repo_host ) === 'wordpress.org' ) {
-						$returned_object = plugins_api( 'plugin_information', $args );
+						// Check wordpress.org only if "Update URI" plugin header is not set or set to wordpress.org.
+						$parsed_repo_url = wp_parse_url( $report['local_info']['UpdateURI'] );
+						$repo_host       = isset( $parsed_repo_url['host'] ) ? $parsed_repo_url['host'] : null;
+						if ( empty( $repo_host ) || strtolower( $repo_host ) === 'w.org' || strtolower( $repo_host ) === 'wordpress.org' ) {
+							$returned_object = plugins_api( 'plugin_information', $args );
+						}
 					}
 
 					// Add the repo info to the report.
@@ -438,7 +468,9 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 				}
 
 				// Repository.
-				if ( isset( $report['local_info']['UpdateURI'] ) ) {
+				if ( isset( $report['ignored'] ) && true === $report['ignored'] ) {
+					$html .= '<td>' . esc_html__( 'Ignored (via config)', 'plugin-report' ) . '</td>';
+				} elseif ( isset( $report['local_info']['UpdateURI'] ) ) {
 					// Parse the UpdateURI's value to get the host.
 					$parsed_repo_url = wp_parse_url( $report['local_info']['UpdateURI'] );
 					// If the URI is valid, extract the host, otherwise we'll use the header value.


### PR DESCRIPTION
## Summary

- Adds `PLUGIN_REPORT_IGNORE` constant (array or comma-separated string) to skip wp.org API lookups
- Ignored plugins show "Ignored (via config)" in the Repository column
- No API call or SVN check is made for ignored slugs
- Cached with the longer `CACHE_LIFETIME_NOREPO` (1 week)

Closes #14

## Configuration

In `wp-config.php`:

```php
define( 'PLUGIN_REPORT_IGNORE', 'yoast-seo-premium,my-internal-plugin' );
```

## Test in WordPress Playground

[Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FwZXJtby9wbHVnaW4tcmVwb3J0L2FyY2hpdmUvcmVmcy9oZWFkcy9mZWF0dXJlL2lnbm9yZS1saXN0LnppcCJ9fSx7InN0ZXAiOiJhY3RpdmF0ZVBsdWdpbiIsInBsdWdpblBhdGgiOiJwbHVnaW4tcmVwb3J0LWZlYXR1cmUtaWdub3JlLWxpc3QvcnQtcGx1Z2luLXJlcG9ydC5waHAifSx7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luWmlwRmlsZSI6eyJyZXNvdXJjZSI6InVybCIsInVybCI6Imh0dHBzOi8vZG93bmxvYWRzLndvcmRwcmVzcy5vcmcvcGx1Z2luL2FwZXJtby1hZG1pbmJhci56aXAifX0seyJzdGVwIjoiaW5zdGFsbFBsdWdpbiIsInBsdWdpblppcEZpbGUiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL2Rvd25sb2Fkcy53b3JkcHJlc3Mub3JnL3BsdWdpbi9naXdlYXRoZXIuemlwIn19XX0=)

Pre-installed test plugins: [Apermo Admin Bar](https://wordpress.org/plugins/apermo-adminbar/) (outdated), [giWeather](https://wordpress.org/plugins/giweather/) (closed/removed)

To test the ignore feature in Playground, add this to `wp-config.php` via the PHP console:
```php
define( 'PLUGIN_REPORT_IGNORE', 'apermo-adminbar' );
```
Then clear cache and reload — Apermo Admin Bar should show "Ignored (via config)".

## Test plan

- [ ] Without the constant defined, all plugins behave as before
- [ ] With `PLUGIN_REPORT_IGNORE` set as comma-separated string, listed plugins show "Ignored (via config)"
- [ ] With `PLUGIN_REPORT_IGNORE` set as array, same behavior
- [ ] Ignored plugins still show name, author, version, activation status
- [ ] Clear cache and verify ignored plugins don't trigger API calls