### PR TITLE
Fix version sorting for unequal segment counts

### DIFF
--- a/js/tablesort.dotsep.min.js
+++ b/js/tablesort.dotsep.min.js
@@ -3,4 +3,4 @@
  * http://tristen.ca/tablesort/demo/
  * Copyright (c) 2025 ; Licensed MIT
 */
-Tablesort.extend("dotsep",function(t){return/^(\d+\.)+\d+$/.test(t)},function(t,r){t=t.split("."),r=r.split(".");for(var e,n,i=0,s=t.length;i<s;i++)if((e=parseInt(t[i],10))!==(n=parseInt(r[i],10))){if(n<e)return-1;if(e<n)return 1}return 0});
+Tablesort.extend("dotsep",function(t){return/^(\d+\.)+\d+$/.test(t)},function(t,r){t=t.split("."),r=r.split(".");for(var e,n,i=0,s=Math.max(t.length,r.length);i<s;i++){e=i<t.length?parseInt(t[i],10):0;n=i<r.length?parseInt(r[i],10):0;if(e!==n){if(n<e)return-1;if(e<n)return 1}}return 0});


### PR DESCRIPTION
## Summary

The `dotsep` tablesort comparator only iterated over the shorter version string's segments, so `6.8` and `6.8.2` were treated as equal. The fix iterates over the longer of the two and treats missing segments as `0`, so `6.8` (= `6.8.0`) correctly sorts before `6.8.2`.

Fixes #65

## Test in WordPress Playground

**Before (develop — broken sort):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL1pvZGlhYzE5NzgvcGx1Z2luLXJlcG9ydC9hcmNoaXZlL3JlZnMvaGVhZHMvZGV2ZWxvcC56aXAifX0seyJzdGVwIjoiYWN0aXZhdGVQbHVnaW4iLCJwbHVnaW5QYXRoIjoicGx1Z2luLXJlcG9ydC1kZXZlbG9wL3J0LXBsdWdpbi1yZXBvcnQucGhwIn0seyJzdGVwIjoiaW5zdGFsbFBsdWdpbiIsInBsdWdpblppcEZpbGUiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL2Rvd25sb2Fkcy53b3JkcHJlc3Mub3JnL3BsdWdpbi9hcGN1LW1hbmFnZXIuNC4xLjAuemlwIn19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FmcmFnZW4vZ2l0LXVwZGF0ZXIvcmVsZWFzZXMvZG93bmxvYWQvMTIuOC4wL2dpdC11cGRhdGVyLTEyLjguMC56aXAifX1dLCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfX0=)

**After (this branch — fixed sort):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FwZXJtby9wbHVnaW4tcmVwb3J0L2FyY2hpdmUvcmVmcy9oZWFkcy9maXgvZG90c2VwLXNvcnQuemlwIn19LHsic3RlcCI6ImFjdGl2YXRlUGx1Z2luIiwicGx1Z2luUGF0aCI6InBsdWdpbi1yZXBvcnQtZml4LWRvdHNlcC1zb3J0L3J0LXBsdWdpbi1yZXBvcnQucGhwIn0seyJzdGVwIjoiaW5zdGFsbFBsdWdpbiIsInBsdWdpblppcEZpbGUiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL2Rvd25sb2Fkcy53b3JkcHJlc3Mub3JnL3BsdWdpbi9hcGN1LW1hbmFnZXIuNC4xLjAuemlwIn19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FmcmFnZW4vZ2l0LXVwZGF0ZXIvcmVsZWFzZXMvZG93bmxvYWQvMTIuOC4wL2dpdC11cGRhdGVyLTEyLjguMC56aXAifX1dLCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfX0=)

Pre-installed test plugins: [APCu Manager](https://wordpress.org/plugins/apcu-manager/) v4.1.0, [Git Updater](https://github.com/afragen/git-updater/releases/tag/12.8.0) v12.8.0 — these reproduce the original issue from #65 where `6.8` and `6.8.2` sort incorrectly.

## Test plan

- [ ] Open the **Before** link, click "Tested up to WP version" to sort — `6.8` and `6.8.2` sort as equal (wrong)
- [ ] Open the **After** link, click the same column — `6.8` sorts before `6.8.2` (ascending) and after it (descending)
- [ ] Verify equal versions (e.g. `6.8` and `6.8`) still sort as equal