### PR TITLE
Use TextDomain as slug for single-file plugins

### DIFF
--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -144,7 +144,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			echo '<tbody>';
 
 			foreach ( $plugins as $key => $plugin ) {
-				$slug      = $this->get_plugin_slug( $key );
+				$slug      = $this->get_plugin_slug( $key, $plugin );
 				$cache_key = $this->create_cache_key( $slug );
 				$cache     = get_site_transient( $cache_key );
 				if ( $cache ) {
@@ -204,7 +204,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			$plugins = get_plugins();
 			$slugs   = array();
 			foreach ( $plugins as $key => $plugin ) {
-				$slugs[] = $this->get_plugin_slug( $key );
+				$slugs[] = $this->get_plugin_slug( $key, $plugin );
 			}
 			return $slugs;
 		}
@@ -213,14 +213,20 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 		/**
 		 * Convert a plugin's file path into its slug.
 		 *
-		 * @param string $file  Plugin file path.
+		 * @param string $file         Plugin file path.
+		 * @param array  $plugin_data  Optional plugin header data from get_plugins().
 		 */
-		private function get_plugin_slug( $file ) {
+		private function get_plugin_slug( $file, $plugin_data = array() ) {
 			if ( strpos( $file, '/' ) !== false ) {
 				$parts = explode( '/', $file );
-			} else {
-				$parts = explode( '.', $file );
+				return sanitize_title( $parts[0] );
 			}
+			// Single-file plugin (e.g. hello.php): prefer TextDomain as slug,
+			// since the filename alone often doesn't match the wp.org slug.
+			if ( ! empty( $plugin_data['TextDomain'] ) ) {
+				return sanitize_title( $plugin_data['TextDomain'] );
+			}
+			$parts = explode( '.', $file );
 			return sanitize_title( $parts[0] );
 		}
 
@@ -293,7 +299,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 
 					// Get the locally available info, and add it to the report.
 					foreach ( $plugins as $key => $plugin ) {
-						if ( $this->get_plugin_slug( $key ) === $slug ) {
+						if ( $this->get_plugin_slug( $key, $plugin ) === $slug ) {
 
 							// Translate plugin data.
 							$textdomain = $plugin['TextDomain'];
@@ -742,7 +748,7 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 			$plugins = get_plugins();
 			// Loop through the plugins array, and delete cache items.
 			foreach ( $plugins as $key => $plugin ) {
-				$slug = $this->get_plugin_slug( $key );
+				$slug = $this->get_plugin_slug( $key, $plugin );
 				$this->clear_cache_item( $slug );
 			}
 		}
@@ -765,9 +771,11 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 		public function upgrade_delete_cache_items( $upgrader, $data ) {
 			// Check if plugins have been upgraded by WP.
 			if ( isset( $data ) && isset( $data['plugins'] ) && is_array( $data['plugins'] ) ) {
+				$plugins = get_plugins();
 				// Loop through the plugins, and delete the associated cache items.
 				foreach ( $data['plugins'] as $key => $value ) {
-					$slug = $this->get_plugin_slug( $value );
+					$plugin_data = isset( $plugins[ $value ] ) ? $plugins[ $value ] : array();
+					$slug        = $this->get_plugin_slug( $value, $plugin_data );
 					$this->clear_cache_item( $slug );
 				}
 			}


### PR DESCRIPTION
## Summary

- For single-file plugins (no subdirectory), use the `TextDomain` header as the slug instead of the filename
- Fixes Hello Dolly (`hello.php`) being reported as "not found" — its TextDomain `hello-dolly` matches the wp.org slug, while the filename-derived `hello` does not
- Generic fix, not a Hello Dolly special case — works for any single-file plugin
- Plugins in subdirectories are unaffected (directory name is still used)

Fixes #78

## Context

`get_plugin_slug()` derives the slug from the plugin's file path. For `plugin-name/plugin-name.php`, the directory name matches the wp.org slug. But single-file plugins like `hello.php` have no directory — the code strips the extension to get `hello`, which doesn't match the actual wp.org slug `hello-dolly`.

The `TextDomain` header reliably matches the wp.org slug for virtually all plugins. Using it as the slug source for single-file plugins resolves the mismatch.

## Test in WordPress Playground

Hello Dolly is bundled with WordPress, so no extra plugins needed to reproduce.

**Before (develop — Hello Dolly shows "not found"):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luWmlwRmlsZSI6eyJyZXNvdXJjZSI6InVybCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ab2RpYWMxOTc4L3BsdWdpbi1yZXBvcnQvYXJjaGl2ZS9yZWZzL2hlYWRzL2RldmVsb3AuemlwIn19LHsic3RlcCI6ImFjdGl2YXRlUGx1Z2luIiwicGx1Z2luUGF0aCI6InBsdWdpbi1yZXBvcnQtZGV2ZWxvcC9ydC1wbHVnaW4tcmVwb3J0LnBocCJ9LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vYXBlcm1vLWFkbWluYmFyLnppcCJ9fV19)

**After (this branch — Hello Dolly resolved correctly):** [Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luWmlwRmlsZSI6eyJyZXNvdXJjZSI6InVybCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9hcGVybW8vcGx1Z2luLXJlcG9ydC9hcmNoaXZlL3JlZnMvaGVhZHMvZml4L3NpbmdsZS1maWxlLXBsdWdpbi1zbHVnLnppcCJ9fSx7InN0ZXAiOiJhY3RpdmF0ZVBsdWdpbiIsInBsdWdpblBhdGgiOiJwbHVnaW4tcmVwb3J0LWZpeC1zaW5nbGUtZmlsZS1wbHVnaW4tc2x1Zy9ydC1wbHVnaW4tcmVwb3J0LnBocCJ9LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vYXBlcm1vLWFkbWluYmFyLnppcCJ9fV19)

Pre-installed test plugins: [Apermo Admin Bar](https://wordpress.org/plugins/apermo-adminbar/) (outdated) — Hello Dolly is bundled with WordPress.

## Test plan

- [x] Open the **Before** link — Hello Dolly row shows "wordpress.org, plugin not found" and "No data available" everywhere
- [x] Open the **After** link — Hello Dolly row shows "wordpress.org" with correct version, last update, tested up to, and rating
- [x] Verify all other plugins still display correctly in the **After** link