### PR TITLE
Handle interrupted AJAX calls gracefully

### DIFF
--- a/js/plugin-report.js
+++ b/js/plugin-report.js
@@ -54,13 +54,26 @@ jQuery(document).ready( function( $ ){
 		};
 
 		jQuery.post( ajaxurl, data, function(response) {
-			// parse the response
-			const obj = JSON.parse(response);
-			// replace the temporary table row with the new data
-			$('#plugin-report-table .plugin-report-row-temp-' + slug ).replaceWith( obj.html );
-			// on to the next...
+			try {
+				const obj = JSON.parse(response);
+				$('#plugin-report-table .plugin-report-row-temp-' + slug ).replaceWith( obj.html );
+			} catch (e) {
+				rtpr_replace_with_error( slug );
+			}
+			rtpr_process_next_plugin();
+		}).fail( function() {
+			rtpr_replace_with_error( slug );
 			rtpr_process_next_plugin();
 		});
+	}
+
+
+	function rtpr_replace_with_error( slug ){
+		const cols = plugin_report_vars.cols_per_row || 9;
+		const msg = plugin_report_vars.ajax_error || 'Error';
+		$('#plugin-report-table .plugin-report-row-temp-' + slug ).replaceWith(
+			'<tr class="pluginreport-row-error"><td colspan="' + cols + '">' + msg + '</td></tr>'
+		);
 	}
 
 	// kick things off

--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -190,6 +190,8 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 				'export_btn'        => __( 'Export .csv file', 'plugin-report' ),
 				'plugin_url_header' => __( 'Plugin URL', 'plugin-report' ),
 				'author_url_header' => __( 'Author URL', 'plugin-report' ),
+				'ajax_error'        => __( 'Error fetching plugin info.', 'plugin-report' ),
+				'cols_per_row'      => self::COLS_PER_ROW,
 			);
 			wp_localize_script( 'plugin-report-js', 'plugin_report_vars', $vars );
 			// Enqueue admin CSS file.


### PR DESCRIPTION
## Summary

- Adds `.fail()` handler to the AJAX call — a network error or server 500 now shows an error row instead of stopping the entire chain
- Wraps `JSON.parse` in try/catch for malformed responses
- Processing continues to the next plugin in both failure cases
- Error message is translatable via the existing i18n system

Fixes #67

Relates to #92 which prevents the server-side from failing in the first place — this PR handles the case where the request itself fails (network, timeout, server error).

## Test in WordPress Playground

[Open in WordPress Playground](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wbHVnaW5zLnBocD9wYWdlPXBsdWdpbl9yZXBvcnQiLCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2FwZXJtby9wbHVnaW4tcmVwb3J0L2FyY2hpdmUvcmVmcy9oZWFkcy9maXgvYWpheC1lcnJvci1oYW5kbGluZy56aXAifX0seyJzdGVwIjoiYWN0aXZhdGVQbHVnaW4iLCJwbHVnaW5QYXRoIjoicGx1Z2luLXJlcG9ydC1maXgtYWpheC1lcnJvci1oYW5kbGluZy9ydC1wbHVnaW4tcmVwb3J0LnBocCJ9LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vYXBlcm1vLWFkbWluYmFyLnppcCJ9LCJvcHRpb25zIjp7ImFjdGl2YXRlIjpmYWxzZX19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5aaXBGaWxlIjp7InJlc291cmNlIjoidXJsIiwidXJsIjoiaHR0cHM6Ly9kb3dubG9hZHMud29yZHByZXNzLm9yZy9wbHVnaW4vZ2l3ZWF0aGVyLnppcCJ9LCJvcHRpb25zIjp7ImFjdGl2YXRlIjpmYWxzZX19XX0=)

Pre-installed test plugins: [Apermo Admin Bar](https://wordpress.org/plugins/apermo-adminbar/) (outdated), [giWeather](https://wordpress.org/plugins/giweather/) (closed/removed)

## Test plan

- [ ] Verify normal operation still works (all plugins load)
- [ ] Simulate failure: throttle network in DevTools or block the AJAX URL — verify error row appears and remaining plugins still load
- [ ] Verify progress bar completes even when some requests fail