### PR TITLE
Fix WordPress Coding Standards CI check

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -7,6 +7,7 @@
 # Files
 /.distignore
 /.gitignore
+/.phpcs.xml.dist
 /.wp-env.json
 /composer.json
 /composer.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,7 @@ jobs:
         uses: wordpress/plugin-check-action@v1.1.6
         with:
           wp-version: "latest"
+          # Development-only files that ship excluded via .distignore but are
+          # present in the CI checkout; skip them so Plugin Check doesn't flag
+          # them as hidden/application files.
+          exclude-files: .wp-env.json,.phpcs.xml.dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: WPCS check
       uses: 10up/wpcs-action@stable
       with:
-        standard: WordPress
+        standard: .phpcs.xml.dist
         paths: .
 
   plugin-check:

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<ruleset name="Plugin Report">
+	<description>Coding standards for the Plugin Report plugin.</description>
+
+	<!-- Show sniff codes and progress; the CI workflow passes the path to scan. -->
+	<arg value="ps"/>
+	<arg name="extensions" value="php"/>
+
+	<!-- Directories that don't need linting. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+
+	<rule ref="WordPress">
+		<!--
+		The plugin ships as a single bootstrap file named after the plugin
+		(rt-plugin-report.php). Renaming it to class-*.php would break the
+		plugin entry point, so the class-file naming rule does not apply.
+		-->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+	</rule>
+
+	<!-- Recognise the plugin's text domain. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="plugin-report"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Recognise the plugin's global prefixes. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="RT_Plugin_Report"/>
+				<element value="rt_plugin_report"/>
+				<element value="plugin_report"/>
+			</property>
+		</properties>
+	</rule>
+</ruleset>

--- a/rt-plugin-report.php
+++ b/rt-plugin-report.php
@@ -464,14 +464,12 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 							// Plugin is available on wp.org.
 							$html .= '<td class="' . esc_attr( self::CSS_CLASS_LOW ) . '">wordpress.org</td>';
 						}
+					} elseif ( $parsed_repo_url && isset( $parsed_repo_url['host'] ) ) {
+						// Update URI is a valid URL, display the host.
+						$html .= '<td class="' . esc_attr( self::CSS_CLASS_MED ) . '">' . esc_html( $repo_host ) . '</td>';
 					} else {
-						if ( $parsed_repo_url && isset( $parsed_repo_url['host'] ) ) { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found
-							// Update URI is a valid URL, display the host.
-							$html .= '<td class="' . esc_attr( self::CSS_CLASS_MED ) . '">' . esc_html( $repo_host ) . '</td>';
-						} else {
-							// Some other value (like 'false'), so assume updates are disabled.
-							$html .= '<td class="' . esc_attr( self::CSS_CLASS_MED ) . '">' . esc_html__( 'Updates disabled', 'plugin-report' ) . '</td>';
-						}
+						// Some other value (like 'false'), so assume updates are disabled.
+						$html .= '<td class="' . esc_attr( self::CSS_CLASS_MED ) . '">' . esc_html__( 'Updates disabled', 'plugin-report' ) . '</td>';
 					}
 				} elseif ( version_compare( $wp_version, '5.8', '<' ) ) {
 					$html .= $this->render_error_cell( esc_html__( 'Only available in WP 5.8+', 'plugin-report' ) );
@@ -531,12 +529,10 @@ if ( is_admin() && ! class_exists( 'RT_Plugin_Report' ) ) {
 				// Auto-update.
 				if ( version_compare( $wp_version, '5.5', '<' ) ) {
 					$html .= '<td>' . esc_html__( 'Requires WordPress 5.5 or higher', 'plugin-report' ) . '</td>';
+				} elseif ( isset( $report['auto-update'] ) && $report['auto-update'] ) {
+					$html .= '<td class="' . esc_attr( self::CSS_CLASS_LOW ) . '">' . esc_html__( 'Enabled', 'plugin-report' ) . '</td>';
 				} else {
-					if ( isset( $report['auto-update'] ) && $report['auto-update'] ) { // phpcs:ignore Universal.ControlStructures.DisallowLonelyIf.Found
-						$html .= '<td class="' . esc_attr( self::CSS_CLASS_LOW ) . '">' . esc_html__( 'Enabled', 'plugin-report' ) . '</td>';
-					} else {
-						$html .= '<td>' . esc_html__( 'Not enabled', 'plugin-report' ) . '</td>';
-					}
+					$html .= '<td>' . esc_html__( 'Not enabled', 'plugin-report' ) . '</td>';
 				}
 
 				// Last updates.


### PR DESCRIPTION
## Summary

Makes the **WordPress Coding Standards** and **Plugin Check** CI jobs pass.

### Coding Standards (3 errors)

- Add a project `.phpcs.xml.dist` ruleset that extends the `WordPress`
  standard and excludes `WordPress.Files.FileName.InvalidClassFileName`.
  The plugin ships as a single bootstrap file named after the plugin
  (`rt-plugin-report.php`); renaming it to `class-*.php` would break the
  entry point, so this sniff does not apply. The ruleset also configures
  the text domain (`plugin-report`) and global prefixes.
- Point the CI WPCS step at the ruleset (`standard: .phpcs.xml.dist`).
- Exclude `.phpcs.xml.dist` from the distributed plugin zip via `.distignore`.
- Convert the two `else { if (...) }` blocks in `render_table_row()` to
  `elseif`, resolving `Universal.ControlStructures.DisallowLonelyIf`. This
  also removes the two `// phpcs:ignore` comments that never took effect —
  they were placed on the `if` line, but the sniff reports the violation on
  the `else` line above. Behaviour is unchanged.

### Plugin Check (hidden_files / application_files errors)

Plugin Check scans the raw repo checkout, so it flagged `.wp-env.json` and
`.phpcs.xml.dist` as hidden/application files (`.dist` is a flagged
extension). Both are development-only files already excluded from the
distributed plugin via `.distignore`, so the Plugin Check step now excludes
them with `exclude-files`. Only `ERROR`-type results fail the action, so the
remaining warnings (restricted term "plugin" in the name/slug, the
`RT_Plugin_Report` prefix, auto-update detection, `.github` directory) are
non-blocking and left untouched — they reflect the established, published
plugin and aren't introduced here.

## ⚠️ Rebase note

This branch is cut from current `develop`. Several other open PRs touch
`rt-plugin-report.php` (e.g. #92). **Please rebase this branch once those are
merged** so the `elseif` refactor applies on top of the final line numbers and
avoids conflicts. Kept as a draft until then.

## Disclosure

Claude (Anthropic) assisted with diagnosing the CI failures and preparing this
change. I (the human author) reviewed it and take responsibility for the
contribution.
